### PR TITLE
feat: Pythonコーディング規約を追加・既存規約を拡張

### DIFF
--- a/templates/nextjs-fastapi/.cursor/rules/code_style.mdc
+++ b/templates/nextjs-fastapi/.cursor/rules/code_style.mdc
@@ -1,25 +1,79 @@
 ---
-description:
+description: Code style and formatting guidelines
 globs:
 alwaysApply: true
 ---
 
 # コードスタイルとフォーマット
 
-- フロントエンド（Next.js/TypeScript）:
+## フロントエンド（Next.js/TypeScript）
 
-  - Prettier + ESLint を使用したコードフォーマット
-  - コンポーネント名は PascalCase で命名
-  - 関数名は camelCase で命名
-  - ファイル名は kebab-case で命名
-  - 定数は UPPER_SNAKE_CASE で命名
-  - 型定義ファイルは `*.types.ts` または `types/` ディレクトリ
-  - Server Component はデフォルト、Client Component は `'use client'` ディレクティブを使用
+### フォーマット・リント
 
-- バックエンド（Python/FastAPI）:
+- Prettier + ESLint を使用したコードフォーマット
 
-  - Ruff を使用したコードフォーマット・リント
-  - 関数名は snake_case
-  - クラス名は PascalCase
-  - 型ヒントは必須（Python 3.12+ 記法を推奨）
-  - 非同期関数は `async def` を優先的に使用
+### 命名規則
+
+| 対象 | スタイル | 例 |
+|------|----------|-----|
+| コンポーネント名 | PascalCase | `UserProfile`, `AuthButton` |
+| 関数名 | camelCase | `getUserData`, `handleSubmit` |
+| ファイル名 | kebab-case | `user-profile.tsx`, `api-client.ts` |
+| 定数 | UPPER_SNAKE_CASE | `API_BASE_URL`, `MAX_RETRY_COUNT` |
+| 型定義ファイル | `*.types.ts` または `types/` | `user.types.ts` |
+
+### 真偽値の命名
+
+```typescript
+// 良い例: 明確な接頭辞を使用
+const isActive = true
+const hasPermission = false
+const canEdit = user.isAdmin()
+const shouldRetry = errorCount < MAX_RETRIES
+
+// 悪い例
+const active = true  // isActive の方が明確
+```
+
+### コンポーネント規約
+
+- Server Component はデフォルト
+- Client Component は `'use client'` ディレクティブを使用
+
+## バックエンド（Python/FastAPI）
+
+### フォーマット・リント
+
+- Ruff を使用したコードフォーマット・リント
+- MyPy による型チェック
+
+### 命名規則
+
+| 対象 | スタイル | 例 |
+|------|----------|-----|
+| 関数名 | snake_case | `get_user_data`, `create_order` |
+| クラス名 | PascalCase | `UserService`, `OrderRepository` |
+| 定数 | UPPER_SNAKE_CASE | `MAX_RETRY_COUNT`, `API_TIMEOUT` |
+| プライベート属性 | `_` 接頭辞 | `_balance`, `_validate_amount` |
+
+### 真偽値の命名
+
+```python
+# 良い例: 明確な接頭辞を使用
+is_active = True
+has_permission = False
+can_edit = user.is_admin()
+should_retry = error_count < MAX_RETRIES
+
+# 悪い例
+active = True  # is_active の方が明確
+```
+
+### 型ヒント
+
+- 型ヒントは必須（Python 3.12+ 記法を推奨）
+- 非同期関数は `async def` を優先的に使用
+
+### 詳細規約
+
+Python の詳細なコーディング規約は `.cursor/rules/python_coding.mdc` を参照してください。

--- a/templates/nextjs-fastapi/.cursor/rules/python_coding.mdc
+++ b/templates/nextjs-fastapi/.cursor/rules/python_coding.mdc
@@ -1,0 +1,273 @@
+---
+description: Python/FastAPI backend coding standards
+globs: "**/*.py"
+alwaysApply: false
+---
+
+# Python コーディング規約
+
+PEP 8 および Google Style Guide に準拠した Python コーディング規約です。
+
+## 1. 命名規則
+
+### 基本ルール
+
+```python
+# 変数と関数: snake_case
+user_name = "田中太郎"
+total_count = 100
+
+def calculate_discount_price(original_price: float, discount_rate: float) -> float:
+    return original_price * (1 - discount_rate)
+
+# クラス: PascalCase
+class UserManager:
+    pass
+
+class OrderProcessor:
+    pass
+
+# 定数: UPPER_SNAKE_CASE
+MAX_RETRY_COUNT = 3
+API_TIMEOUT_SECONDS = 30
+DEFAULT_ENCODING = "utf-8"
+```
+
+### プライベート変数・メソッド
+
+```python
+class BankAccount:
+    def __init__(self):
+        self._balance = 0  # プライベート属性（単一アンダースコア）
+        self.__account_number = None  # 強いプライベート属性（名前マングリング）
+
+    def _validate_amount(self, amount: float) -> bool:  # プライベートメソッド
+        return amount > 0
+
+    def deposit(self, amount: float) -> None:  # パブリックメソッド
+        if self._validate_amount(amount):
+            self._balance += amount
+```
+
+### 真偽値の命名
+
+```python
+# 良い例: 明確な接頭辞を使用
+is_active = True
+has_permission = False
+can_edit = user.is_admin()
+should_retry = error_count < MAX_RETRIES
+
+# 悪い例: 真偽値とわかりにくい
+active = True
+permission = False
+```
+
+## 2. 型ヒント
+
+型ヒントは必須です。Python 3.12+ 記法を推奨します。
+
+```python
+from typing import Optional
+
+# 基本的な型ヒント
+def calculate_average(numbers: list[float]) -> float:
+    return sum(numbers) / len(numbers)
+
+# Noneを返す可能性がある場合
+def get_user(user_id: int) -> dict[str, str] | None:
+    user = database.find(user_id)
+    return user if user else None
+
+# 複数の型を受け取る場合
+def process_data(data: str | bytes) -> str:
+    if isinstance(data, bytes):
+        return data.decode("utf-8")
+    return data
+```
+
+## 3. Docstring（Google Style）
+
+```python
+def calculate_discount(
+    original_price: float,
+    discount_rate: float,
+    member_rank: str = "regular"
+) -> float:
+    """商品の割引後価格を計算する。
+
+    会員ランクに応じた追加割引を適用し、最終的な価格を返す。
+    割引率は0.0〜1.0の範囲で指定する。
+
+    Args:
+        original_price: 元の価格（税込）
+        discount_rate: 基本割引率（0.0〜1.0）
+        member_rank: 会員ランク（"regular", "silver", "gold"）
+
+    Returns:
+        割引後の価格
+
+    Raises:
+        ValueError: 割引率が範囲外の場合
+
+    Examples:
+        >>> calculate_discount(1000, 0.1, "regular")
+        900.0
+    """
+    if not 0 <= discount_rate <= 1:
+        raise ValueError("割引率は0.0〜1.0の範囲で指定してください")
+
+    rank_bonus = {"regular": 0, "silver": 0.05, "gold": 0.1}
+    total_discount = discount_rate + rank_bonus.get(member_rank, 0)
+    return original_price * (1 - total_discount)
+```
+
+## 4. インラインコメント
+
+「なぜ」を説明するコメントを書く。自明なコメントは不要。
+
+```python
+def process_payment(amount: float) -> bool:
+    # APIレート制限を回避するため、リトライ間隔を徐々に延ばす
+    for retry in range(MAX_RETRIES):
+        try:
+            return payment_api.charge(amount)
+        except RateLimitError:
+            time.sleep(2 ** retry)  # 指数バックオフ
+
+    # ビジネスルール: 3回失敗したら手動確認に回す
+    notify_admin(f"決済処理失敗: {amount}円")
+    return False
+```
+
+## 5. 単一責任の原則（SRP）
+
+1つの関数は1つの責任のみを持つ。
+
+```python
+# 良い例: 各責任を分離
+def process_user_registration(email: str, password: str) -> User:
+    """ユーザー登録のメインフロー"""
+    validate_user_input(email, password)
+    user = create_user(email, password)
+    send_welcome_email(user.email)
+    log_registration(user)
+    return user
+
+def validate_user_input(email: str, password: str) -> None:
+    """ユーザー入力のバリデーション"""
+    if "@" not in email:
+        raise ValueError("無効なメールアドレス")
+    if len(password) < 8:
+        raise ValueError("パスワードは8文字以上")
+
+def create_user(email: str, password: str) -> User:
+    """ユーザーをデータベースに作成"""
+    hashed_password = hash_password(password)
+    return User.objects.create(email=email, password=hashed_password)
+```
+
+## 6. 早期リターン（ガード節）
+
+ネストを減らすために早期リターンを使用する。
+
+```python
+# 良い例: 早期リターンでネスト解消
+def get_discount_rate(user: User | None) -> float:
+    """ユーザーの割引率を取得"""
+    if user is None:
+        return 0.0
+
+    if not user.is_member:
+        return 0.05
+
+    if user.order_count <= 10:
+        return 0.1
+
+    if user.total_spent > 100000:
+        return 0.2
+
+    return 0.15
+```
+
+## 7. 引数の設計
+
+引数が多すぎる場合はデータクラスでまとめる。
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class UserData:
+    name: str
+    email: str
+    age: int
+    address: str
+    phone: str
+
+def create_user(user_data: UserData) -> User:
+    """ユーザーを作成"""
+    pass
+```
+
+## 8. 比較構文
+
+```python
+# None, True, False の比較は is/is not を使用
+if value is None:
+    pass
+
+# 真偽値の簡潔な書き方
+if flag:  # if flag is True: より簡潔
+    pass
+
+if not flag:  # if flag is False: より簡潔
+    pass
+```
+
+## 9. Pythonic イディオム
+
+```python
+# リスト内包表記
+squares = [x ** 2 for x in range(10)]
+
+# enumerate の活用
+for index, value in enumerate(items):
+    print(f"{index}: {value}")
+
+# zip の活用
+for name, score in zip(names, scores):
+    print(f"{name}: {score}")
+
+# 辞書内包表記
+user_dict = {user.id: user for user in users}
+```
+
+## 10. 関数の長さとネスト
+
+- 関数は20〜30行以内を目安
+- ネストは3レベルまで
+- 複雑な処理は別関数に分割
+
+## 11. EAFP（Easier to Ask for Forgiveness than Permission）
+
+Python では「許可を求めるより許しを請う」スタイルを推奨。
+
+```python
+# Pythonic: EAFP
+try:
+    value = my_dict[key]
+except KeyError:
+    value = default_value
+
+# 非Pythonic: LBYL（Look Before You Leap）
+if key in my_dict:
+    value = my_dict[key]
+else:
+    value = default_value
+```
+
+## 参考資料
+
+- [PEP 8](https://pep8-ja.readthedocs.io/ja/latest/)
+- [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)

--- a/templates/nextjs-fastapi/.cursor/rules/security.mdc
+++ b/templates/nextjs-fastapi/.cursor/rules/security.mdc
@@ -1,5 +1,5 @@
 ---
-description:
+description: Security guidelines and best practices
 globs:
 alwaysApply: true
 ---
@@ -15,16 +15,61 @@ alwaysApply: true
 
 ## 環境変数管理
 
-- 機密情報は必ず環境変数で管理
+機密情報は必ず環境変数で管理する。
+
+```python
+import os
+
+# 良い例: 環境変数から取得
+API_KEY = os.getenv("API_KEY")
+DATABASE_PASSWORD = os.getenv("DB_PASSWORD")
+
+# デフォルト値の設定（機密情報以外）
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///default.db")
+
+# 必須の環境変数チェック
+if not API_KEY:
+    raise ValueError("API_KEY が設定されていません")
+```
+
 - `.env` ファイルは `.gitignore` に追加
 - `.env.example` ファイルでテンプレートを提供
-- 本番環境では環境変数を適切に設定
 
 ## データベースセキュリティ
 
-- SQL インジェクション対策: SQLAlchemy ORM を使用
-- パスワードは必ずハッシュ化（bcrypt 推奨）
-- データベース接続文字列は環境変数で管理
+### SQL インジェクション対策
+
+```python
+# 危険: 文字列連結でSQL作成
+def get_user_unsafe(email: str):
+    query = f"SELECT * FROM users WHERE email = '{email}'"  # 危険!
+    return db.execute(query)
+
+# 良い例: プレースホルダーを使用
+def get_user_safe(email: str):
+    query = "SELECT * FROM users WHERE email = :email"
+    return db.execute(query, {"email": email})
+
+# 良い例: SQLAlchemy ORM を使用
+def get_user_orm(email: str):
+    return db.query(User).filter(User.email == email).first()
+```
+
+### パスワードのハッシュ化
+
+```python
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def hash_password(password: str) -> str:
+    """パスワードをハッシュ化"""
+    return pwd_context.hash(password)
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """パスワードを検証"""
+    return pwd_context.verify(plain_password, hashed_password)
+```
 
 ## API セキュリティ
 
@@ -32,6 +77,32 @@ alwaysApply: true
 - レート制限の実装
 - 入力バリデーション（Pydantic スキーマ）
 - エラーメッセージで機密情報を漏らさない
+
+### 入力バリデーション
+
+```python
+import re
+from pydantic import BaseModel, field_validator
+
+class UserCreate(BaseModel):
+    email: str
+    password: str
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+        if not re.match(pattern, v):
+            raise ValueError("無効なメールアドレス形式です")
+        return v
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("パスワードは8文字以上必要です")
+        return v
+```
 
 ## フロントエンドセキュリティ
 
@@ -47,6 +118,25 @@ alwaysApply: true
 - セキュリティアラートへの迅速な対応
 
 ## ログとモニタリング
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+def process_login(email: str, password: str) -> bool:
+    try:
+        user = authenticate(email, password)
+        logging.info(f"ログイン成功: {email}")
+        return True
+    except AuthenticationError:
+        # パスワードはログに出力しない
+        logging.warning(f"ログイン失敗: {email}")
+        return False
+```
 
 - 機密情報（パスワード、トークン）をログに出力しない
 - 認証・認可の失敗をログに記録

--- a/templates/nextjs-fastapi/.cursor/rules/testing.mdc
+++ b/templates/nextjs-fastapi/.cursor/rules/testing.mdc
@@ -114,3 +114,103 @@ pytest --cov=app           # カバレッジレポート生成
 - データベースのテスト用データをセットアップ
 - モック・スタブを適切に使用
 - テスト間の独立性を保つ（各テストでクリーンアップ）
+
+## 例外のテスト
+
+```python
+import pytest
+
+def test_invalid_email_raises_error():
+    """無効なメールアドレスで例外が発生することを確認"""
+    with pytest.raises(ValueError) as exc_info:
+        validate_email("invalid-email")
+
+    assert "無効なメールアドレス" in str(exc_info.value)
+
+def test_user_not_found_raises_404():
+    """存在しないユーザーで404エラーが発生することを確認"""
+    with pytest.raises(HTTPException) as exc_info:
+        get_user(user_id=99999)
+
+    assert exc_info.value.status_code == 404
+```
+
+## モックを使ったテスト
+
+```python
+from unittest.mock import Mock, patch, AsyncMock
+
+@pytest.mark.asyncio
+async def test_send_email_called():
+    """メール送信が呼び出されることを確認"""
+    with patch("app.services.email.send_email") as mock_send:
+        mock_send.return_value = True
+
+        result = await register_user("test@example.com", "password123")
+
+        mock_send.assert_called_once_with(
+            to="test@example.com",
+            subject="登録ありがとうございます"
+        )
+        assert result.email == "test@example.com"
+
+@pytest.mark.asyncio
+async def test_external_api_mock():
+    """外部APIをモックしてテスト"""
+    mock_response = {"status": "success", "data": {"id": 123}}
+
+    with patch("app.services.external_api.fetch") as mock_fetch:
+        mock_fetch.return_value = AsyncMock(return_value=mock_response)()
+
+        result = await process_external_data()
+
+        assert result["id"] == 123
+```
+
+## フィクスチャの活用
+
+```python
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+@pytest.fixture
+async def db_session():
+    """テスト用データベースセッション"""
+    async with AsyncSession(engine) as session:
+        yield session
+        await session.rollback()
+
+@pytest.fixture
+def sample_user():
+    """テスト用ユーザーデータ"""
+    return {
+        "email": "test@example.com",
+        "name": "Test User",
+        "password": "securepassword123"
+    }
+
+@pytest.mark.asyncio
+async def test_create_user(db_session: AsyncSession, sample_user: dict):
+    """ユーザー作成のテスト"""
+    user = await create_user(db_session, **sample_user)
+
+    assert user.email == sample_user["email"]
+    assert user.name == sample_user["name"]
+```
+
+## カバレッジの確認
+
+```bash
+# カバレッジレポートの生成
+pytest --cov=app --cov-report=html --cov-report=term-missing
+
+# 特定のカバレッジ閾値を設定
+pytest --cov=app --cov-fail-under=80
+```
+
+## テストのベストプラクティス
+
+- **AAA パターン**: Arrange（準備）→ Act（実行）→ Assert（検証）
+- **1テスト1アサーション**: 各テストは1つの振る舞いを検証
+- **テスト名は説明的に**: `test_user_creation_with_valid_data_succeeds`
+- **テストデータは明示的に**: マジックナンバーを避ける

--- a/templates/nextjs-fastapi/CLAUDE.md.template
+++ b/templates/nextjs-fastapi/CLAUDE.md.template
@@ -104,6 +104,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 以下はサマリーです。完全な規約は各ファイルを参照してください:
 
 - **コーディングスタイル**: `.cursor/rules/code_style.mdc`
+- **Pythonコーディング規約**: `.cursor/rules/python_coding.mdc`
 - **コミットメッセージ**: `.cursor/rules/commit_message.mdc`
 - **ブランチ戦略**: `.cursor/rules/branch_strategy.mdc`
 - **テスト規約**: `.cursor/rules/testing.mdc`


### PR DESCRIPTION
- 新規: python_coding.mdc（Python専用の詳細コーディング規約）
  - 命名規則、型ヒント、Docstring、単一責任の原則
  - 早期リターン、引数設計、Pythonic イディオム
- code_style.mdc: 真偽値命名、プライベート変数規約を追加
- security.mdc: SQLインジェクション対策、パスワードハッシュ化のコード例追加
- testing.mdc: 例外テスト、モック、フィクスチャのパターン追加
- CLAUDE.md.template: python_coding.mdcへの参照を追加