### PR TITLE
docs: Spec Kit連携ガイドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,71 @@ domain_specific:
     - "アクセスログの記録"
 ```
 
+## 🔗 Spec Kit との併用（推奨）
+
+このテンプレートは [Spec Kit](https://github.com/github/spec-kit) と組み合わせて使用することで、仕様駆動開発の全フェーズをカバーできます。
+
+### 役割分担
+
+| ツール | 役割 | タイミング |
+|---|---|---|
+| **本テンプレート** | 開発環境・規約の初期化 | プロジェクト開始時（1回） |
+| **Spec Kit** | 要件定義・設計・タスク化 | 機能追加ごと（繰り返し） |
+
+### 併用フロー
+
+```bash
+# Step 1: 本テンプレートでプロジェクト初期化
+git clone https://github.com/IwamuraHayato/spec-driven-dev-template.git
+cd spec-driven-dev-template/generators/
+pip install -r requirements.txt
+python interactive_setup.py
+# → .cursor/rules/, .github/, CLAUDE.md などが生成される
+
+# Step 2: Spec Kit を初期化
+cd ../my-new-project/
+specify init . --ai claude --force
+# → .speckit/, specs/ ディレクトリが追加される
+
+# Step 3: 機能開発サイクル（繰り返し）
+# Claude Code 上で実行:
+/speckit.specify   # 要件定義
+/speckit.plan      # 技術設計
+/speckit.tasks     # タスク分解
+/speckit.implement # 実装（.cursor/rules/ の規約に従う）
+```
+
+### 統合後のディレクトリ構造
+
+```
+my-project/
+├── .speckit/                    # Spec Kit（プロジェクト原則）
+│   └── constitution.md
+├── specs/                       # Spec Kit（機能仕様）
+│   └── feature-xxx/
+│       ├── spec.md
+│       ├── plan.md
+│       └── tasks.md
+├── .cursor/rules/               # 本テンプレート（コーディング規約）
+├── .github/                     # 本テンプレート（Issue/PR/CI）
+├── docs/                        # 本テンプレート（チームルール）
+├── CLAUDE.md                    # 本テンプレート（AI指示書）
+├── frontend/                    # 実装コード
+└── backend/                     # 実装コード
+```
+
+### Spec Kit のインストール
+
+```bash
+# 推奨: 永続インストール
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+
+# または一時使用
+uvx --from git+https://github.com/github/spec-kit.git specify init .
+```
+
+詳細は [Spec Kit 公式リポジトリ](https://github.com/github/spec-kit) を参照してください。
+
 ## 📚 参考プロジェクト
 
 このテンプレートは、以下のプロジェクトから抽出されたベストプラクティスを基にしています:
@@ -188,6 +253,7 @@ MIT License
 
 ## 🔗 関連リンク
 
+- [Spec Kit](https://github.com/github/spec-kit) - 仕様駆動開発ツールキット
 - [Next.js 公式ドキュメント](https://nextjs.org/docs)
 - [FastAPI 公式ドキュメント](https://fastapi.tiangolo.com/)
 - [Claude Code](https://claude.ai/code)

--- a/templates/nextjs-fastapi/CLAUDE.md.template
+++ b/templates/nextjs-fastapi/CLAUDE.md.template
@@ -27,6 +27,44 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **管理者**: サービス運営・管理を行うスタッフ
 - **開発者**: アプリケーション開発・保守を行うエンジニア
 
+### 仕様駆動開発（Spec Kit）
+
+このプロジェクトでは [Spec Kit](https://github.com/github/spec-kit) を使用した仕様駆動開発を推奨しています。
+
+#### Spec Kit コマンド
+
+| コマンド | 目的 | 出力 |
+|---|---|---|
+| `/speckit.constitution` | プロジェクト原則の策定 | `.speckit/constitution.md` |
+| `/speckit.specify` | 要件定義・ユーザーストーリー | `specs/[feature]/spec.md` |
+| `/speckit.plan` | 技術設計・実装計画 | `specs/[feature]/plan.md` |
+| `/speckit.tasks` | タスク分解 | `specs/[feature]/tasks.md` |
+| `/speckit.implement` | 実装実行 | 実装コード |
+
+#### 仕様ディレクトリ構造
+
+```
+specs/
+└── [feature-branch]/
+    ├── spec.md              # ユーザーストーリー・受け入れ基準
+    ├── plan.md              # 実装計画・フェーズ分割
+    ├── data-model.md        # エンティティ・スキーマ定義
+    ├── contracts/           # APIスキーマ・イベント定義
+    └── tasks.md             # 実行可能タスクリスト
+```
+
+#### 開発フロー
+
+```
+1. /speckit.specify   → 要件を定義
+2. /speckit.plan      → 技術設計を策定
+3. /speckit.tasks     → タスクを分解
+4. /speckit.implement → 実装（.cursor/rules/ の規約に従う）
+5. PR作成・レビュー   → .github/ テンプレートを使用
+```
+
+> **Note**: Spec Kit は任意のツールです。使用しない場合は、このセクションを削除してください。
+
 ## 2. アーキテクチャの説明
 
 ### ディレクトリ構造


### PR DESCRIPTION
- CLAUDE.md.template: 仕様駆動開発（Spec Kit）セクションを追加
  - Spec Kitコマンド一覧
  - 仕様ディレクトリ構造
  - 開発フロー
- README.md: Spec Kit併用ガイドを追加
  - 役割分担の説明
  - 併用フロー
  - 統合後のディレクトリ構造
  - インストール方法
  - 関連リンクにSpec Kitを追加