### PR TITLE
fix(template): Claude PR Reviewワークフローの改善

### DIFF
--- a/templates/nextjs-fastapi/.github/workflows/claude-pr-review.yml
+++ b/templates/nextjs-fastapi/.github/workflows/claude-pr-review.yml
@@ -19,12 +19,29 @@ jobs:
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
+      - name: Check API Key
+        id: check-key
+        run: |
+          if [ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
+            echo "has_key=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_key=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip if no API key
+        if: steps.check-key.outputs.has_key == 'false'
+        run: |
+          echo "ANTHROPIC_API_KEY not configured, skipping Claude review"
+          exit 0
+
       - name: Checkout repository
+        if: steps.check-key.outputs.has_key == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Get changed files and latest commit
+        if: steps.check-key.outputs.has_key == 'true'
         id: changed-files
         run: |
           # 最新のコミットハッシュを取得
@@ -57,13 +74,13 @@ jobs:
           fi
 
       - name: Skip if no changes
-        if: steps.changed-files.outputs.has_changes == 'false'
+        if: steps.check-key.outputs.has_key == 'true' && steps.changed-files.outputs.has_changes == 'false'
         run: |
           echo "No changes detected, skipping review"
           exit 0
 
       - name: Check if already reviewed
-        if: steps.changed-files.outputs.has_changes == 'true'
+        if: steps.check-key.outputs.has_key == 'true' && steps.changed-files.outputs.has_changes == 'true'
         id: review-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,13 +98,13 @@ jobs:
           fi
 
       - name: Skip if already reviewed
-        if: steps.changed-files.outputs.has_changes == 'true' && steps.review-check.outputs.already_reviewed == 'true'
+        if: steps.check-key.outputs.has_key == 'true' && steps.changed-files.outputs.has_changes == 'true' && steps.review-check.outputs.already_reviewed == 'true'
         run: |
           echo "Latest commit already reviewed, skipping"
           exit 0
 
       - name: Claude API Code Review
-        if: steps.changed-files.outputs.has_changes == 'true' && steps.review-check.outputs.already_reviewed == 'false'
+        if: steps.check-key.outputs.has_key == 'true' && steps.changed-files.outputs.has_changes == 'true' && steps.review-check.outputs.already_reviewed == 'false'
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
@@ -95,7 +112,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: "claude-sonnet-4-20250514"
           trigger_phrase: "@claude"
-          timeout_minutes: "30"
+          timeout_minutes: "5"
           direct_prompt: |
             You are a helpful assistant that reviews code changes in a pull request for {{PROJECT_NAME}}.
             Review the code changes and provide feedback in Japanese, referencing @docs/dev/REVIEW.md.


### PR DESCRIPTION
## 概要

20251212-tableau-appプロジェクトで実証済みの改善内容をテンプレートに反映します。

## 修正内容

### 1. API Keyチェック機能の追加

**追加ステップ**:
- `Check API Key`: ANTHROPIC_API_KEYの存在確認
- `Skip if no API key`: API Key未設定時はワークフロー全体をスキップ

**利点**:
- 新規プロジェクト立ち上げ時にAPI Keyが未設定でもエラーにならない
- 柔軟な運用が可能（後からAPI Keyを設定できる）

### 2. 全ステップへの条件追加

全てのステップに `steps.check-key.outputs.has_key == 'true'` 条件を追加：
- Checkout repository
- Get changed files and latest commit
- Skip if no changes
- Check if already reviewed
- Skip if already reviewed
- Claude API Code Review

**利点**: API Keyがない場合に無駄な処理をスキップし、効率化

### 3. timeout_minutes の最適化

\`\`\`yaml
# 修正前
timeout_minutes: "30"

# 修正後
timeout_minutes: "5"
\`\`\`

**理由**:
- 30分だとハングした際に気づきにくい
- 実測で1-2分で完了するため、5分で十分
- CIパイプラインの高速化

## テスト結果

20251212-tableau-appプロジェクトで実際に動作確認済み：
- ✅ API Key設定済み環境で正常動作
- ✅ タイムアウトが5分で適切に機能
- ✅ 重複レビュー防止機能が正常動作

## チェックリスト

- [x] 既存プロジェクトで動作確認済み
- [x] コミットメッセージが規約に準拠
- [x] 下位互換性を保持（既存プロジェクトに影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)